### PR TITLE
Prevent crash when mPrevEvent is null

### DIFF
--- a/library/src/main/java/com/almeros/android/multitouch/MoveGestureDetector.java
+++ b/library/src/main/java/com/almeros/android/multitouch/MoveGestureDetector.java
@@ -102,12 +102,9 @@ public class MoveGestureDetector extends BaseGestureDetector {
                 break;
 
             case MotionEvent.ACTION_MOVE:
-                //updateStateByEvent looks for information within mPrevEvent
-                //However, if the gesture started before the detector was attached,
-                //ACTION_MOVE happens but mPrevEvent is null, and code will crash
-                // @BaseGestureDetector.updateStateByEvent() line 102.
-                //This check will simply ignore the current movement if it didn't track it from
-                // the start.
+                // If the gesture started before this detector was attached (somehow), 
+		// mPrevEvent will be null at this point and BaseGestureDetector's 
+		// updateStateByEvent() will crash. The following check will prevent this.
                 if (mPrevEvent == null) {
                     return;
                 }

--- a/library/src/main/java/com/almeros/android/multitouch/MoveGestureDetector.java
+++ b/library/src/main/java/com/almeros/android/multitouch/MoveGestureDetector.java
@@ -102,6 +102,15 @@ public class MoveGestureDetector extends BaseGestureDetector {
                 break;
 
             case MotionEvent.ACTION_MOVE:
+                //updateStateByEvent looks for information within mPrevEvent
+                //However, if the gesture started before the detector was attached,
+                //ACTION_MOVE happens but mPrevEvent is null, and code will crash
+                // @BaseGestureDetector.updateStateByEvent() line 102.
+                //This check will simply ignore the current movement if it didn't track it from
+                // the start.
+                if (mPrevEvent == null) {
+                    return;
+                }
                 updateStateByEvent(event);
 
 				// Only accept the event if our relative pressure is within


### PR DESCRIPTION
I came across the same issue as mentioned here during the development of one of my apps :
https://github.com/mapbox/mapbox-gl-native/issues/5047

After investigation, it appears that the GestureDetector didn't receive ACTION_DOWN (user has finger down before the view is fully loaded and listeners attached), and starts directly processing ACTION_MOVE.

In that instance, mPrevEvent is null.

My solution will simply ignore any processing that can happen during the ACTION_MOVE.
The rest of the logic stays in place (especially ACTION_UP and ACTION_CANCEL), so that the state is clean when a new gesture happens.