### PR TITLE
Fix getRawX and getRawY logic

### DIFF
--- a/library/src/main/java/com/almeros/android/multitouch/TwoFingerGestureDetector.java
+++ b/library/src/main/java/com/almeros/android/multitouch/TwoFingerGestureDetector.java
@@ -119,10 +119,10 @@ public abstract class TwoFingerGestureDetector extends BaseGestureDetector {
      * @return
      */
     protected static float getRawX(MotionEvent event, int pointerIndex) {
-        float offset = event.getX() - event.getRawX();
-        if(pointerIndex < event.getPointerCount()){
-        	return event.getX(pointerIndex) + offset;
-        } 
+        float viewToRaw = event.getRawX() - event.getX();
+        if (pointerIndex < event.getPointerCount()) {
+            return event.getX(pointerIndex) + viewToRaw;
+        }
         return 0f;
     }
 
@@ -133,10 +133,10 @@ public abstract class TwoFingerGestureDetector extends BaseGestureDetector {
      * @return
      */
     protected static float getRawY(MotionEvent event, int pointerIndex) {
-        float offset = event.getY() - event.getRawY();
-        if(pointerIndex < event.getPointerCount()){
-        	return event.getY(pointerIndex) + offset;
-        } 
+        float viewToRaw = event.getRawY() - event.getY();
+        if (pointerIndex < event.getPointerCount()) {
+            return event.getY(pointerIndex) + viewToRaw;
+        }
         return 0f;
     }
 


### PR DESCRIPTION
Previous logic was only correct for cases where `getRawX` is the same as `getX`

Resolves https://github.com/Almeros/android-gesture-detectors/issues/30